### PR TITLE
Update to frontend 4.2.0

### DIFF
--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_AllValues.approved.html
@@ -34,7 +34,6 @@ test-error</span>
                name="test-name-prefix-test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_AllValues.approved.html
@@ -6,14 +6,10 @@
           aria-describedby="test-fieldset-described-by test-id-error test-id-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
 
 <div class="govuk-hint"
       id="test-id-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoDescribedBy.approved.html
@@ -5,14 +5,10 @@
 <fieldset class="govuk-fieldset"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
 
         <div class="govuk-date-input test-css-class">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoDescribedBy.approved.html
@@ -22,7 +22,6 @@ test legend</legend>
                name="test-name-prefix-test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoErrorMessage.approved.html
@@ -28,7 +28,6 @@ test-hint</div>
                name="test-name-prefix-test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoErrorMessage.approved.html
@@ -6,14 +6,10 @@
           aria-describedby="test-fieldset-described-by test-id-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
 
 <div class="govuk-hint"
       id="test-id-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFieldSet.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFieldSet.approved.html
@@ -26,7 +26,6 @@ test-error</span>
                name="test-name-prefix-test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFormGroup.approved.html
@@ -34,7 +34,6 @@ test-error</span>
                name="test-name-prefix-test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFormGroup.approved.html
@@ -6,14 +6,10 @@
           aria-describedby="test-fieldset-described-by test-id-error test-id-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
 
 <div class="govuk-hint"
       id="test-id-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoHint.approved.html
@@ -29,7 +29,6 @@ test-error</span>
                name="test-name-prefix-test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoHint.approved.html
@@ -6,14 +6,10 @@
           aria-describedby="test-fieldset-described-by test-id-error"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
 
 <span class="govuk-error-message"
       id="test-id-error"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoNamePrefix.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoNamePrefix.approved.html
@@ -34,7 +34,6 @@ test-error</span>
                name="test-item-name"
                type="number"
                value="test item value"
-               pattern="[0-9]*"
                >
     </div>
 </div>        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoNamePrefix.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoNamePrefix.approved.html
@@ -6,14 +6,10 @@
           aria-describedby="test-fieldset-described-by test-id-error test-id-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
 
 <div class="govuk-hint"
       id="test-id-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_AllValues.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoDescribedBy.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes ">
 
+    <label class="govuk-label"  for="test-id">
 
-
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-             <input class="govuk-file-upload  cssClass "
+test-label    </label>
+    <input class="govuk-file-upload  cssClass "
            id="test-id"
            name="test-name"
            type="file"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoError.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoError.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes ">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoHint.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <span class="govuk-error-message"
       id="test-id-error"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
@@ -4,14 +4,10 @@
           aria-describedby="test-fieldset-described-by test-id-prefix-error test-id-prefix-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
             <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
 <div class="govuk-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
@@ -4,14 +4,10 @@
           aria-describedby="test-fieldset-described-by test-id-prefix-error test-id-prefix-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
             <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
 <div class="govuk-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoDescribedBy.approved.html
@@ -3,14 +3,10 @@
 <fieldset class="govuk-fieldset"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
             <div class="govuk-form-group form-group-classes ">
                 <div class="govuk-checkboxes test-css-class " 
                                           attr-name="attr-value">

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
@@ -4,14 +4,10 @@
           aria-describedby="test-fieldset-described-by test-id-prefix-hint"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
             <div class="govuk-form-group form-group-classes ">
 
 <div class="govuk-hint"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
@@ -4,14 +4,10 @@
           aria-describedby="test-fieldset-described-by test-id-prefix-error"
           >
 
+<legend class="govuk-fieldset__legend">
 
-
-
-
-            <legend class="govuk-fieldset__legend">
-
-test legend            </legend>
-             
+test legend</legend>
+    
             <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
 <span class="govuk-error-message"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_AllValues.approved.html
@@ -13,16 +13,10 @@
 data-aria-controls="conditional-test-id" aria-describedby="test-id-item-hint"            attr-name="attr-value">
 
 
+    <label class="govuk-label govuk-checkboxes__label "  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label govuk-checkboxes__label "
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint govuk-checkboxes__hint"
       id="test-id-item-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Checked.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Checked.approved.html
@@ -13,16 +13,10 @@
 data-aria-controls="conditional-test-id" aria-describedby="test-id-item-hint"            attr-name="attr-value">
 
 
+    <label class="govuk-label govuk-checkboxes__label "  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label govuk-checkboxes__label "
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint govuk-checkboxes__hint"
       id="test-id-item-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Disabled.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Disabled.approved.html
@@ -13,16 +13,10 @@
 data-aria-controls="conditional-test-id" aria-describedby="test-id-item-hint"            attr-name="attr-value">
 
 
+    <label class="govuk-label govuk-checkboxes__label "  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label govuk-checkboxes__label "
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint govuk-checkboxes__hint"
       id="test-id-item-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoConditional.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoConditional.approved.html
@@ -13,16 +13,10 @@
 aria-describedby="test-id-item-hint"            attr-name="attr-value">
 
 
+    <label class="govuk-label govuk-checkboxes__label "  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label govuk-checkboxes__label "
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint govuk-checkboxes__hint"
       id="test-id-item-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoHint.approved.html
@@ -13,16 +13,10 @@
 data-aria-controls="conditional-test-id"            attr-name="attr-value">
 
 
+    <label class="govuk-label govuk-checkboxes__label "  for="test-id">
 
-
-
-
-            <label class="govuk-label govuk-checkboxes__label "
-                   
-                   for="test-id">
-
-test-label            </label>
-         </div>
+test-label    </label>
+</div>
         <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
              id="conditional-test-id">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_AllValues.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_DisabledItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_DisabledItem.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoAttributes.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoAttributes.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoDescribedBy.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes ">
 
+    <label class="govuk-label"  for="test-id">
 
-
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-             <select class="govuk-select test-css-class "
+test-label    </label>
+    <select class="govuk-select test-css-class "
             id="test-id"
             name="test-name"
             attr-name="attr-value">

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoErrorMessage.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes ">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoFormGroup.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <div class="govuk-hint"
       id="test-id-hint"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoHint.approved.html
@@ -1,16 +1,10 @@
 ﻿
 <div class="govuk-form-group form-group-classes govuk-form-group--error">
 
+    <label class="govuk-label"  for="test-id">
 
+test-label    </label>
 
-
-
-            <label class="govuk-label"
-                   
-                   for="test-id">
-
-test-label            </label>
-         
 <span class="govuk-error-message"
       id="test-id-error"
       >

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_UnselectedItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_UnselectedItem.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_AllValues.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoDescribedBy.approved.html
@@ -1,6 +1,6 @@
 ﻿<div class="govuk-form-group form-group-classes ">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <textarea class="govuk-textarea test-css-class " id="test-id" name="test-name" rows="3" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
 </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoError.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoError.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes ">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoFormGroup.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoHint.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <span class="govuk-error-message" id="test-id-error">
     <span class="govuk-visually-hidden">Error</span>
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_AllValues.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoAppendix.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoAppendix.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoDescribedBy.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes ">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <input class="govuk-input test-css-class " id="test-id" name="test-name" type="text" value="test value" autocomplete="test autocomplete" spellcheck="true" pattern="test-pattern" inputmode="test-input-mode" attr-name="attr-value" />
 
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoError.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoError.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes ">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoFormGroup.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <div class="govuk-hint" id="test-id-hint">
 
 test-hint</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextInputTests.Render_NoHint.approved.html
@@ -1,7 +1,7 @@
 ﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
   <label class="govuk-label" for="test-id">
 
-test-label            </label>
+test-label    </label>
   <span class="govuk-error-message" id="test-id-error">
     <span class="govuk-visually-hidden">Error</span>
 

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/CharacterCount.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/CharacterCount.cshtml
@@ -31,8 +31,7 @@
             });
     }
     <span id="@($"{Model.Id}-info")"
-          class="govuk-hint govuk-character-count__message"
-          aria-live="polite">
+          class="govuk-hint govuk-character-count__message">
         You can enter up to @(Model.MaxLength ?? Model.MaxWords) @(Model.MaxLength != null ? "characters" : "words")
     </span>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItem.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItem.cshtml
@@ -11,6 +11,7 @@
                name="@(Model.Name)"
                type="number"
                value="@(Model.Value)"
+               pattern="@(Model.Pattern)"
                @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     </div>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItem.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItem.cshtml
@@ -11,7 +11,6 @@
                name="@(Model.Name)"
                type="number"
                value="@(Model.Value)"
-               pattern="@(Model.Pattern)"
                @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     </div>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItemViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItemViewModel.cs
@@ -30,6 +30,11 @@ namespace GovUkDesignSystem.GovUkDesignSystemComponents
         public string Autocomplete { get; set; }
 
         /// <summary>
+        /// 	Attribute to provide a regular expression pattern, used to match allowed character combinations for the input value.
+        /// </summary>
+        public string Pattern { get; set; }
+        
+        /// <summary>
         ///     Classes to add to date input item.
         /// </summary>
         public string Classes { get; set; }

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItemViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItemViewModel.cs
@@ -30,11 +30,6 @@ namespace GovUkDesignSystem.GovUkDesignSystemComponents
         public string Autocomplete { get; set; }
 
         /// <summary>
-        /// 	Attribute to provide a regular expression pattern, used to match allowed character combinations for the input value.
-        /// </summary>
-        public string Pattern { get; set; } = "[0-9]*";
-
-        /// <summary>
         ///     Classes to add to date input item.
         /// </summary>
         public string Classes { get; set; }

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ErrorSummary.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ErrorSummary.cshtml
@@ -5,7 +5,6 @@
 <div class="govuk-error-summary @(Model.Classes)"
      aria-labelledby="error-summary-title"
      role="alert"
-     tabindex="-1"
      data-module="govuk-error-summary"
      @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Header.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Header.cshtml
@@ -35,7 +35,7 @@
             <div class="govuk-header__content">
                 @if (!string.IsNullOrEmpty(Model.ServiceName))
                 {
-                    <a href="@(Model.ServiceUrl)" class="govuk-header__link govuk-header__link--service-name">
+                    <a href="@(Model.ServiceUrl)" class="govuk-header__link govuk-header__service-name">
                         @(Model.ServiceName)
                     </a>
                 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This is a collection of [Gov.UK Design System](https://design-system.service.gov
 
 It's the C# equivalent of the [Gov.UK Prototyping Kit](https://govuk-prototype-kit.herokuapp.com/docs) Nunjucks templates.
 
+To use this library your project will need to include content from the GOV.UK Frontend NPM package used by the components.
+For an example of how to include the content from the NPM package see [package.json](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta/blob/develop/HerPublicWebsite/package.json)
+from the DESNZ HER project.
+This library currently works with GOV.UK Frontend v4.2.0.
+
 
 #### Warning: work in progress
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is a collection of [Gov.UK Design System](https://design-system.service.gov
 
 It's the C# equivalent of the [Gov.UK Prototyping Kit](https://govuk-prototype-kit.herokuapp.com/docs) Nunjucks templates.
 
-To use this library your project will need to include content from the GOV.UK Frontend NPM package used by the components.
+To use this library your project will need to include some content from the [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/)
+[NPM package](https://www.npmjs.com/package/govuk-frontend) used by the components.
 For an example of how to include the content from the NPM package see [package.json](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta/blob/develop/HerPublicWebsite/package.json)
 from the DESNZ HER project.
 This library currently works with GOV.UK Frontend v4.2.0.


### PR DESCRIPTION
Frontend 4.2.0 adds support for pagination controls.

Make a few changes suggested by the GOV.UK Frontend release notes from 4.0.0 to 4.2.0
https://github.com/alphagov/govuk-frontend/releases

Also update approval tests that were missed previously