### PR TITLE
Fix WarningText.cshtml fallback text CSS class

### DIFF
--- a/GovUkDesignSystem/GovUkDesignSystemComponents/WarningText.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/WarningText.cshtml
@@ -4,7 +4,7 @@
      @( Html.Raw(Model.Attributes.ToTagAttributes()))>
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">@Model.IconFallbackText</span>
+        <span class="govuk-visually-hidden">@Model.IconFallbackText</span>
         @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
     </strong>
 </div>


### PR DESCRIPTION
GDS now recommends govuk-visually-hidden, govuk-warning-text__assistive no longer hides the text